### PR TITLE
编译Kext模块加入 VoodooPS2 和 VoodooI2C

### DIFF
--- a/HackintoshBuild/Command/About/download.command
+++ b/HackintoshBuild/Command/About/download.command
@@ -20,6 +20,8 @@ for i in ${selectedArray[*]}; do
         echo bugprogrammer_$dirname
     elif [[ $i =~ "MacProMemoryNotificationDisabler" ]]; then
         echo "MacProMemoryNotificationDisabler"
+    elif [[ $i =~ "VoodooPS2Controller" ]]; then
+        echo "VoodooPS2"
     else
         echo $dirname
     fi

--- a/HackintoshBuild/TabViewController/ViewControllerUpdate.swift
+++ b/HackintoshBuild/TabViewController/ViewControllerUpdate.swift
@@ -48,7 +48,9 @@ class ViewControllerUpdate: NSViewController {
         "AtherosE2200Ethernet",
         "RealtekRTL8111",
         "NVMeFix",
-        "MacProMemoryNotificationDisabler"
+        "MacProMemoryNotificationDisabler",
+        "VoodooPS2",
+        "VoodooI2C"
     ]
     
     let url: [String] = [
@@ -67,7 +69,9 @@ class ViewControllerUpdate: NSViewController {
         "https://github.com/Mieze/AtherosE2200Ethernet",
         "https://github.com/Mieze/RTL8111_driver_for_OS_X",
         "https://github.com/acidanthera/NVMeFix",
-        "https://github.com/IOIIIO/MacProMemoryNotificationDisabler"
+        "https://github.com/IOIIIO/MacProMemoryNotificationDisabler",
+        "https://github.com/acidanthera/VoodooPS2",
+        "https://github.com/VoodooI2C/VoodooI2C"
     ]
     
     var currentVersion: [String] = []

--- a/HackintoshBuild/TabViewController/ViewControllerUpdate.swift
+++ b/HackintoshBuild/TabViewController/ViewControllerUpdate.swift
@@ -262,6 +262,12 @@ class ViewControllerUpdate: NSViewController {
         else if kexts[row] == "MacProMemoryNotificationDisabler" {
             downloadURL = url[row] + "/releases/download/v" + Lastest[row] + "/" + "MPMND" + "-v" + Lastest[row] + "-Release.zip"
         }
+        else if kexts[row] == "VoodooPS2" {
+            downloadURL = url[row] + "/releases/download/" + Lastest[row] + "/" + "VoodooPS2Controller" + "-" + Lastest[row] + "-RELEASE.zip"
+        }
+        else if kexts[row] == "VoodooI2C" {
+            downloadURL = url[row] + "/releases/download/" + Lastest[row] + "/" + kexts[row] + "-" + Lastest[row] + ".zip"
+        }
         else if "acidanthera_WhateverGreen bugprogrammer_WhateverGreen".contains(kexts[row]) {
             downloadURL = url[row] + "/releases/download/" + Lastest[row] + "/" + "WhateverGreen" + "-" + Lastest[row] + "-RELEASE.zip"
         }

--- a/HackintoshBuild/ViewControllerBuild.swift
+++ b/HackintoshBuild/ViewControllerBuild.swift
@@ -50,7 +50,9 @@ class ViewControllerBuild: NSViewController {
         "AtherosE2200Ethernet",
         "RTL8111",
         "NVMeFix",
-        "MacProMemoryNotificationDisabler"
+        "MacProMemoryNotificationDisabler",
+        "VoodooPS2",
+        "VoodooI2C"
     ]
     
     override func viewWillAppear() {


### PR DESCRIPTION
* 编译Kext模块加入 VoodooPS2 和 VoodooI2C 
* ~优化Lilu依赖编译逻辑，参考 Acidanthera仓库CI 和 https://github.com/acidanthera/Lilu/blob/master/Lilu/Scripts/bootstrap.sh~
* Kext下载模块加入 VoodooPS2 和 VoodooI2C
* 回滚 Lilu 依赖编译逻辑，并参考原有方案编译 VoodooInput。